### PR TITLE
Update pachinko timers and add knowledge graph

### DIFF
--- a/knowledge_graph.json
+++ b/knowledge_graph.json
@@ -1,0 +1,33 @@
+{
+  "entities": {
+    "QuantumSim": {
+      "features": [
+        "sceneObjects",
+        "state",
+        "timers",
+        "mode",
+        "camera",
+        "renderer",
+        "controls",
+        "ui",
+        "theme"
+      ],
+      "relationships": {
+        "mode": "handles Wave, Particle, and Pachinko modules",
+        "timers": "manage update loops and intervals"
+      },
+      "timers": ["pachinkoSpawn", "pachinkoPhys"]
+    },
+    "Mode": {
+      "features": ["wave", "particle", "pachinko"],
+      "relationships": {
+        "pachinko": "spawns balls and runs physics"
+      }
+    }
+  },
+  "observations": [
+    "Repo uses Three.js for rendering",
+    "Pachinko mode uses setInterval for spawn and physics updates",
+    "Timers updated to separate spawn and physics intervals"
+  ]
+}

--- a/quantumsim.js
+++ b/quantumsim.js
@@ -65,7 +65,8 @@
     timers: {
       wave: null,
       particle: null,
-      pachinko: null,
+      pachinkoSpawn: null,
+      pachinkoPhys: null,
       render: null
     },
 
@@ -160,7 +161,8 @@
       cancelAnimationFrame(this.timers.render);
       clearInterval(this.timers.wave);
       clearInterval(this.timers.particle);
-      clearInterval(this.timers.pachinko);
+      clearInterval(this.timers.pachinkoSpawn);
+      clearInterval(this.timers.pachinkoPhys);
     },
 
     /**
@@ -517,7 +519,8 @@
       stopAll() {
         clearInterval(QuantumSim.timers.wave);
         clearInterval(QuantumSim.timers.particle);
-        clearInterval(QuantumSim.timers.pachinko);
+        clearInterval(QuantumSim.timers.pachinkoSpawn);
+        clearInterval(QuantumSim.timers.pachinkoPhys);
       },
 
       update(time) {


### PR DESCRIPTION
## Summary
- add an initial knowledge graph JSON to capture repo structure
- track separate pachinko timers `pachinkoSpawn` and `pachinkoPhys`
- clear these new timers during cleanup and mode transitions

## Testing
- `npm test` *(fails: server runs indefinitely and was manually cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68436c3245e0832a90186e497f8c639e