### PR TITLE
Add wheel gear launcher control

### DIFF
--- a/enhanced-index.html
+++ b/enhanced-index.html
@@ -21,6 +21,7 @@
   <script src="debug.js"></script>
   <!-- Load enhanced simulator implementation -->
   <script src="quantumsim.js"></script>
+  <script src="wheel-launcher.js"></script>
   <script src="main.js"></script>
   <script>
     // Make the loading overlay visible immediately
@@ -103,7 +104,13 @@
         <button class="camera-preset-btn" id="cam-artistic" data-preset="artistic">A</button>
         <button class="camera-preset-btn" id="cam-topdown" data-preset="topdown">T</button>
         <button class="camera-preset-btn" id="cam-follow" data-preset="follow">F</button>
-      </div> 
+      </div>
+      <div class="wheel-control">
+        <div class="wheel-track">
+          <div class="wheel-gear" id="wheelGear"></div>
+        </div>
+        <input type="range" id="nozzleRange" min="30" max="150" value="90">
+      </div>
     </div>
     
     <!-- Info Modal -->

--- a/index.html
+++ b/index.html
@@ -86,7 +86,13 @@
         <button class="camera-preset-btn" id="cam-artistic" data-preset="artistic">A</button>
         <button class="camera-preset-btn" id="cam-topdown" data-preset="topdown">T</button>
         <button class="camera-preset-btn" id="cam-follow" data-preset="follow">F</button>
-      </div> 
+      </div>
+      <div class="wheel-control">
+        <div class="wheel-track">
+          <div class="wheel-gear" id="wheelGear"></div>
+        </div>
+        <input type="range" id="nozzleRange" min="30" max="150" value="90">
+      </div>
     </div>
     
     <!-- Info Modal -->
@@ -121,6 +127,7 @@
     </div>
   </div>
   <script src="script.js"></script>
+  <script src="wheel-launcher.js"></script>
   <script src="animate.js"></script>
 </body>
 </html>

--- a/knowledge-graph.json
+++ b/knowledge-graph.json
@@ -6,6 +6,7 @@
     {"id": "Pachinko Mode", "features": ["peg grid", "random walk"]},
     {"id": "Theme", "features": ["Carnival vs Default", "Neo-deco styling"]},
     {"id": "UI", "features": ["dat.GUI", "camera controls"]},
+    {"id": "Wheel Gear", "features": ["launch control", "angle input"]},
     {"id": "Environment", "features": ["Star field background", "Neon gradient"]}
   ],
   "relationships": [
@@ -13,7 +14,8 @@
     {"from": "Scene", "to": "Particle Mode", "type": "renders"},
     {"from": "Scene", "to": "Pachinko Mode", "type": "renders"},
     {"from": "Theme", "to": "Scene", "type": "styles"},
-    {"from": "UI", "to": "Scene", "type": "controls"}
+    {"from": "UI", "to": "Scene", "type": "controls"},
+    {"from": "Wheel Gear", "to": "Pachinko Mode", "type": "launches"}
   ],
   "observations": "Repo uses Three.js to visualize quantum duality through Wave, Particle and Pachinko modes. A new theme system toggles a neon carnival look or a starry default background."
 }

--- a/knowledge_graph.json
+++ b/knowledge_graph.json
@@ -23,6 +23,12 @@
       "relationships": {
         "pachinko": "spawns balls and runs physics"
       }
+    },
+    "WheelGear": {
+      "features": ["launch force", "nozzle angle"],
+      "relationships": {
+        "QuantumSim": "triggers pachinko.launch"
+      }
     }
   },
   "observations": [

--- a/quantumsim.js
+++ b/quantumsim.js
@@ -35,6 +35,7 @@
         roundDuration: 30,
         pegRows: 12,
         binCount: 10,
+        nozzleAngle: 90,
         gravityStrength: 9.8,
         quantumUncertainty: 0.001,
         relativistic: false,
@@ -466,6 +467,7 @@
         f1.add(p,'mode',['Wave','Particle','Pachinko']).onChange(m=>QuantumSim.mode.switch(m));
         f1.add(p,'electrons',100,10000).step(100);
         f1.add(p,'roundDuration',5,60).step(5);
+        f1.add(p,'nozzleAngle',30,150).name('Nozzle Angle');
         f1.add(p,'reset').name('↺ Reset Simulation');
         f1.open();
         // Additional folders omitted for brevity
@@ -594,38 +596,12 @@
             }
           }
       
-          // --- 3) Spawn & update loop ---
-          const total  = params.electrons;
-          const roundT = params.roundDuration * 1000;
-          const spawnInterval = roundT / total;
-          const gravity = params.gravityStrength;
-          const noiseAmt= params.quantumUncertainty;
-      
-          let spawned = 0;
-          // Drop timer
-          timers.pachinkoSpawn = setInterval(() => {
-            if (spawned++ >= total) {
-              clearInterval(timers.pachinkoSpawn);
-              return;
-            }
-            // create ball
-            const mesh = new THREE.Mesh(
-              new THREE.SphereGeometry(0.03,12,12),
-              new THREE.MeshStandardMaterial({ color: 0xffaa00 })
-            );
-            // start at top center
-            mesh.position.set(0, height/2 + 0.1, 0);
-            scene.add(mesh);
-      
-            // initial downward velocity
-            const vel = new THREE.Vector3(
-              (Math.random()-0.5)*noiseAmt,
-              -1,
-              0
-            ).multiplyScalar(2);
-      
-            state.activeBalls.push({ mesh, vel });
-          }, spawnInterval);
+          // --- 3) Store board state ---
+          state.boardHeight   = height;
+          state.pachinkoGravity = params.gravityStrength;
+          state.pachinkoNoise   = params.quantumUncertainty;
+
+          // No automatic spawn timer; balls are launched via WheelGear
       
           // Physics update (60fps)
           timers.pachinkoPhys = setInterval(() => {
@@ -673,7 +649,39 @@
             });
           }, 16);
         },
-      
+
+        /** Launch balls using current nozzle and force */
+        launch(force=0.5) {
+          const scene  = QuantumSim.sceneObjects.scene;
+          const state  = QuantumSim.state;
+          const params = state.params;
+          const height = state.boardHeight || params.pegRows * 0.4;
+          const angle  = THREE.MathUtils.degToRad(params.nozzleAngle);
+          const count  = Math.max(1, Math.round(force * 5));
+          const speed  = 2 + force * 3;
+          const noise  = state.pachinkoNoise * force;
+
+          for (let i=0;i<count;i++) {
+            const mesh = new THREE.Mesh(
+              new THREE.SphereGeometry(0.03,12,12),
+              new THREE.MeshStandardMaterial({ color: 0xffaa00 })
+            );
+            mesh.position.set(0, height/2 + 0.1, 0);
+            scene.add(mesh);
+
+            const dir = new THREE.Vector3(
+              Math.sin(angle),
+              -Math.cos(angle),
+              0
+            );
+            dir.x += (Math.random()-0.5)*noise;
+            dir.y += (Math.random()-0.5)*noise;
+            dir.normalize();
+            const vel = dir.multiplyScalar(speed);
+            state.activeBalls.push({mesh,vel});
+          }
+        },
+
         /** Stop Pachinko entirely */
         stop() {
           clearInterval(QuantumSim.timers.pachinkoSpawn);

--- a/styles.css
+++ b/styles.css
@@ -730,6 +730,36 @@ body.carnival-theme {
   box-shadow: 0 0 5px var(--color-neon-tertiary);
 }
 
+/* Wheel gear launcher */
+.wheel-control {
+  display:flex;
+  align-items:center;
+  margin-top:10px;
+  flex-direction:column;
+}
+.wheel-track {
+  width:20px;
+  height:100px;
+  border:1px solid var(--color-neon-primary);
+  border-radius:10px;
+  position:relative;
+  background:rgba(26,26,34,0.6);
+  margin-bottom:8px;
+}
+.wheel-gear {
+  width:18px;
+  height:18px;
+  background:var(--color-neon-primary);
+  border-radius:50%;
+  position:absolute;
+  bottom:0;
+  left:1px;
+  cursor:pointer;
+}
+.wheel-control input[type="range"] {
+  width:100px;
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .header h1 {

--- a/wheel-launcher.js
+++ b/wheel-launcher.js
@@ -1,0 +1,41 @@
+/**
+ * UI module for the vertical wheel gear that launches balls.
+ * Adds pointer interactions and sends force values to QuantumSim.
+ */
+(function(global){
+  'use strict';
+  const WheelGear = {
+    _startY:0,
+    _force:0,
+    init(){
+      const gear=document.getElementById('wheelGear');
+      if(!gear) return;
+      gear.addEventListener('pointerdown',e=>{
+        this._startY=e.clientY;
+        gear.setPointerCapture(e.pointerId);
+      });
+      gear.addEventListener('pointermove',e=>{
+        if(!this._startY) return;
+        const dy=Math.max(0,this._startY-e.clientY);
+        this._force=Math.min(1,dy/100);
+        gear.style.transform=`translateY(${-this._force*40}px)`;
+      });
+      gear.addEventListener('pointerup',e=>{
+        gear.releasePointerCapture(e.pointerId);
+        const f=this._force;
+        this._startY=0;this._force=0;
+        gear.style.transform='';
+        global.QuantumSim?.mode?.pachinko?.launch(f);
+      });
+    }
+  };
+  document.addEventListener('DOMContentLoaded',()=>{
+    WheelGear.init();
+    const range=document.getElementById('nozzleRange');
+    range?.addEventListener('input',e=>{
+      const val=parseFloat(e.target.value);
+      if(!isNaN(val) && global.QuantumSim) global.QuantumSim.state.params.nozzleAngle=val;
+    });
+  });
+  global.WheelGear=WheelGear;
+})(window);


### PR DESCRIPTION
## Summary
- create `wheel-launcher.js` for adjustable force and nozzle angle
- expose nozzleAngle param and dat.GUI slider
- add wheel gear markup and script tags
- handle wheel-based ball launch in Pachinko mode
- document wheel gear in the knowledge graph

## Testing
- `npm test` *(fails: lite-server output only)*

------
https://chatgpt.com/codex/tasks/task_e_6872e19bf22c832aa7bb6ee80d40ea1f